### PR TITLE
Update SN to 23xxxxxxxx for i2c address change

### DIFF
--- a/examples/exampleI2cAddressChange/README.md
+++ b/examples/exampleI2cAddressChange/README.md
@@ -60,7 +60,7 @@ sensors to the same pin on the ESP32 Board, you can for example use a Breadboard
 
 ## Limitations
 
-- The feature is only supported by SLF3x sensors with a serial number above 22xxxxxxxx.
+- The feature is only supported by SLF3x sensors with a serial number above 23xxxxxxxx.
 - After a soft or hard reset the  I²C address is set back to the default address 0x08. A soft reset is triggered by a speical I2C command, see `i2c_soft_reset()` in the example, and a hard reset is triggered by a power cylce of the sensor.
 
 ## Further readings

--- a/examples/exampleI2cAddressChange/exampleI2cAddressChange.ino
+++ b/examples/exampleI2cAddressChange/exampleI2cAddressChange.ino
@@ -77,7 +77,7 @@ void i2c_soft_reset() {
  *   after the reset)
  * * PIN1 of the sensor for which you want to change the address must be
  *   connected to a GPIO pin
- * * Note that only sensors with a serial number above 22xxxxxxxx have the IRQn
+ * * Note that only sensors with a serial number above 23xxxxxxxx have the IRQn
  *   pin
  *
  * @note The I2C address is not configured permanently, you need to run the


### PR DESCRIPTION
Only sensors with serial number starting with 23xxx or newer are guaranteed to support the i2c address change. Not all sensors with serial number 22xxx support the feature.